### PR TITLE
Fix token header handling

### DIFF
--- a/src/middlewares/authMiddleware.js
+++ b/src/middlewares/authMiddleware.js
@@ -5,7 +5,9 @@ const authMiddleware = async (req,res,next)=>{
 
     console.log("Inside auth");
     //get token from header in the request
-    const token=req.header('Authorization')?.replace('Bearer','');
+    // Extract token from 'Authorization' header and remove the 'Bearer ' prefix
+    const authHeader = req.header('Authorization');
+    const token = authHeader ? authHeader.replace('Bearer ', '').trim() : null;
 
     //token is not valid, access will be denied
     if(!token){

--- a/src/utils/redisClient.js
+++ b/src/utils/redisClient.js
@@ -12,8 +12,8 @@ redisClient.on('connect',()=>{
     console.log('Connected to redis');
 })
 
-redisClient.on('errort',(error)=>{
-    console.log('Redis connection error',err);
+redisClient.on('error',(error)=>{
+    console.error('Redis connection error', error);
 })
 redisClient.connect();
 


### PR DESCRIPTION
## Summary
- handle missing Authorization header gracefully in auth middleware

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687cdb3d41148330a6e4413aebd9743f